### PR TITLE
refactor: Change snapshot functionality from taking EBS to AMI snapshots

### DIFF
--- a/client/src/app/shared/components/snapshot-confirmation-dialog/snapshot-confirmation-dialog.component.ts
+++ b/client/src/app/shared/components/snapshot-confirmation-dialog/snapshot-confirmation-dialog.component.ts
@@ -30,10 +30,11 @@ export class SnapshotConfirmationDialogComponent {
       id: this.data.instanceElement.deploymentId,
       instanceId: this.data.instanceElement.ec2InstanceId,
       hostname: this.data.instanceElement.hostname,
-      region: Region.AP_SOUTHEAST_3,
+      region: this.data.instanceElement.availabilityZone,
       ami: this.data.instanceElement.ami,
       serverSize: this.data.instanceElement.serverSize,
       lifecycle: this.data.instanceElement.lifecycle,
+      timeToExpire: this.data.instanceElement.timeToExpire,
     };
     this.apiService
       .captureInstanceSnapshopt(apiPayload)

--- a/client/src/app/shared/model/deployment-request.ts
+++ b/client/src/app/shared/model/deployment-request.ts
@@ -1,4 +1,4 @@
-import { Lifecycle, Region, TimeUnit } from '../enum/dropdown.enum';
+import { Lifecycle, TimeUnit } from '../enum/dropdown.enum';
 
 export class DeploymentApiRequest {
   id?: string;
@@ -6,8 +6,9 @@ export class DeploymentApiRequest {
   ami!: number;
   serverSize!: string;
   hostname!: string;
-  region!: Region;
+  region!: string;
   lifecycle!: Lifecycle;
   ttlValue?: number;
   ttlUnit?: string;
+  timeToExpire?: number;
 }

--- a/ecr-scripts/instance.tf
+++ b/ecr-scripts/instance.tf
@@ -52,7 +52,7 @@ resource "aws_spot_instance_request" "my_deployed_spot_instances" {
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
   user_data              = data.aws_s3_object.user_data.body
   tags = {
-    Name         = "${each.value.hostname}.${data.aws_route53_zone.hosted_zone.name}"
+    Name         = each.value.hostname
     Hostname     = replace(each.value.hostname, "/.${data.aws_route53_zone.hosted_zone.name}/", "")
     DeploymentID = each.value.id
     TimeToExpire = each.value.timeToExpire

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -122,14 +122,13 @@ func UpdateRecord(id string, updateData models.DynamoDBData) error {
 		return ErrHostnameExists
 	}
 
+	// there was a field for region, removed for now as region is static
 	update := expression.Set(
 		expression.Name("ami"), expression.Value(updateData.Ami),
 	).Set(
 		expression.Name("serverSize"), expression.Value(updateData.ServerSize),
 	).Set(
 		expression.Name("hostname"), expression.Value(updateData.Hostname),
-	).Set(
-		expression.Name("region"), expression.Value(updateData.Region),
 	).Set(
 		expression.Name("creationUser"), expression.Value(updateData.CreationUser),
 	).Set(

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -135,6 +135,8 @@ func UpdateRecord(id string, updateData models.DynamoDBData) error {
 		expression.Name("lifecycle"), expression.Value(updateData.Lifecycle),
 	).Set(
 		expression.Name("timeToExpire"), expression.Value(updateData.TimeToExpire),
+	).Set(
+		expression.Name("snapShot"), expression.Value(updateData.SnapShot),
 	)
 
 	// Build the update expression.

--- a/server/handler.go
+++ b/server/handler.go
@@ -399,7 +399,7 @@ func CaptureInstanceSnapshot(c *gin.Context) {
 	log.Println("update request for id:", id)
 
 	var snapshotID string
-	if snapshotID, err = instance.CaptureInstanceSnapshot(req.InstanceID); err != nil {
+	if snapshotID, err = instance.CaptureInstanceImage(req.InstanceID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -236,38 +236,22 @@ func DeleteAllInstanceRequests(c *gin.Context) {
 }
 
 func GetAWSData(c *gin.Context) {
-	// read config file
-	configFile, err := os.ReadFile("config.json")
+	// read env variable
+	configEnv := os.Getenv("MY_AMI_ATTR")
+	regionEnv := os.Getenv("MY_REGION")
+
+	config := models.Config{}
+
+	err := json.Unmarshal([]byte(configEnv), &config)
 	if err != nil {
-		log.Printf("Failed to read config file: %v", err)
-		abortWithLog(c, http.StatusInternalServerError, err)
+		log.Printf("Failed to describe unmarshal ec2 configuration: %v", err)
 		return
 	}
 
-	// parse config file
-	var config models.Config
-	if err := json.Unmarshal(configFile, &config); err != nil {
-		log.Printf("Error parsing config file: %v", err)
-		abortWithLog(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	// instanceTypes, err := GetEC2InstanceTypes(c.Request.Context())
-	// if err != nil {
-	// 	log.Printf("Error fetching EC2 instance types: %v", err)
-	// 	abortWithLog(c, http.StatusInternalServerError, err)
-	// 	return
-	// }
-
-	// config.ServerSizes = instanceTypes
+	// add region env
+	config.Region = []string{regionEnv}
 
 	c.JSON(http.StatusOK, config)
-}
-
-func abortWithLog(c *gin.Context, statusCode int, err error) {
-	if abortErr := c.AbortWithError(statusCode, err); abortErr != nil {
-		log.Printf("Failed to abort with status %d: %v", statusCode, abortErr)
-	}
 }
 
 func GetEC2InstanceTypes(ctx context.Context) ([]string, error) {

--- a/server/handler.go
+++ b/server/handler.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -411,6 +412,11 @@ func CaptureInstanceSnapshot(c *gin.Context) {
 		return
 	}
 
+	timeToLive, err := strconv.ParseInt(req.TimeToExpire, 10, 64)
+	if err != nil {
+		log.Printf("Failed to parse ttl with error %v", err)
+	}
+
 	// Convert request to DynamoDBData struct
 	data := models.DynamoDBData{
 		ID:                id,
@@ -422,6 +428,7 @@ func CaptureInstanceSnapshot(c *gin.Context) {
 		Lifecycle:         req.Lifecycle,
 		SnapShot:          snapshotID,
 		ContentDeployment: req.ContentDeployment,
+		TimeToExpire:      timeToLive,
 	}
 
 	// Update the DynamoDB row to include the captured snapshot ID

--- a/server/handler.go
+++ b/server/handler.go
@@ -251,6 +251,13 @@ func GetAWSData(c *gin.Context) {
 	// add region env
 	config.Region = []string{regionEnv}
 
+	// get list of snapshot AMIs, and add to the AMI available
+	config.Ami, err = instance.GetAvailableAmis(config.Ami)
+	if err != nil {
+		log.Printf("Failed to get list of AMIs: %v", err)
+		return
+	}
+
 	c.JSON(http.StatusOK, config)
 }
 

--- a/server/instance/instance.go
+++ b/server/instance/instance.go
@@ -174,7 +174,7 @@ func CaptureInstanceImage(instanceID string) (string, error) {
 			return "", err
 		}
 	}
-	
+
 	// get tags of the instance
 	describeInstanceTags := &ec2.DescribeTagsInput{
 		Filters: []types.Filter{
@@ -202,12 +202,12 @@ func CaptureInstanceImage(instanceID string) (string, error) {
 	now := time.Now()
 	date := now.Format(time.DateOnly)
 	time := fmt.Sprintf("%d%d%d", now.Hour(), now.Minute(), now.Second())
-	formatted_name := instanceName + "_" + date + "_" + time
+	formattedName := instanceName + "_" + date + "_" + time
 
 	// snapshot the instance
 	imageInput := &ec2.CreateImageInput{
 		InstanceId: aws.String(instanceID),
-		Name:       aws.String(formatted_name),
+		Name:       aws.String(formattedName),
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: types.ResourceType("image"),

--- a/server/instance/instance.go
+++ b/server/instance/instance.go
@@ -54,11 +54,11 @@ func GetDeployedInstances() ([]models.DeploymentResponse, error) {
 						Values: []string{*instance.InstanceId},
 					},
 					{
-						Name: aws.String("is-public"),
+						Name:   aws.String("is-public"),
 						Values: []string{"false"},
 					},
 				}
-			
+
 				imageResult, err := getImage(filter)
 				if err != nil {
 					log.Printf("failed to resolve image for instance %s: %v", *instance.InstanceId, err)
@@ -139,7 +139,7 @@ func getLifecycle(lifecycle types.InstanceLifecycleType) string {
 	return string(lifecycle)
 }
 
-func CaptureInstanceImage(instanceID string) (string, error) {	
+func CaptureInstanceImage(instanceID string) (string, error) {
 	// get tags of the instance
 	describeInstanceTags := &ec2.DescribeTagsInput{
 		Filters: []types.Filter{
@@ -170,7 +170,7 @@ func CaptureInstanceImage(instanceID string) (string, error) {
 			Values: []string{instanceName},
 		},
 		{
-			Name: aws.String("is-public"),
+			Name:   aws.String("is-public"),
 			Values: []string{"false"},
 		},
 	}
@@ -199,13 +199,13 @@ func CaptureInstanceImage(instanceID string) (string, error) {
 	// snapshot the instance
 	imageInput := &ec2.CreateImageInput{
 		InstanceId: aws.String(instanceID),
-		Name: aws.String(instanceName),
+		Name:       aws.String(instanceName),
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: types.ResourceType("image"),
 				Tags: []types.Tag{
 					{
-						Key: aws.String("DeployedBy"),
+						Key:   aws.String("DeployedBy"),
 						Value: aws.String("turbo-deploy"),
 					},
 				},
@@ -226,7 +226,7 @@ func GetAvailableAmis(amilist []string) ([]string, error) {
 	// check if an image for that instance already exists
 	filter := []types.Filter{
 		{
-			Name: aws.String("is-public"),
+			Name:   aws.String("is-public"),
 			Values: []string{"false"},
 		},
 		{
@@ -261,7 +261,7 @@ func getImage(filter []types.Filter) (*ec2.DescribeImagesOutput, error) {
 
 	imageResult, err := ec2Client.DescribeImages(context.Background(), describeInstanceImage)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
 
 	return imageResult, nil

--- a/server/instance/instance.go
+++ b/server/instance/instance.go
@@ -232,6 +232,38 @@ func CaptureInstanceImage(instanceID string) (string, error) {
 	return aws.ToString(result.ImageId), nil
 }
 
+func GetAvailableAmis(amilist []string) ([]string, error) {
+	// check if an image for that instance already exists
+	filter := []types.Filter{
+		{
+			Name: aws.String("is-public"),
+			Values: []string{"false"},
+		},
+		{
+			Name:   aws.String("tag:DeployedBy"),
+			Values: []string{"turbo-deploy"},
+		},
+	}
+
+	imageResult, err := getImage(filter)
+	if err != nil {
+		log.Printf("failed to retrieve images: %v", err)
+	}
+
+	// if it exists grab it
+	if len(imageResult.Images) == 0 {
+		log.Printf("No images returned for extra listing")
+	} else {
+		for i := range imageResult.Images {
+			image := imageResult.Images[i]
+			log.Printf("Image %s found, appending to the list...", *image.ImageId)
+			amilist = append(amilist, *image.ImageId)
+		}
+	}
+
+	return amilist, nil
+}
+
 func getImage(filter []types.Filter) (*ec2.DescribeImagesOutput, error) {
 	describeInstanceImage := &ec2.DescribeImagesInput{
 		Filters: filter,

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -36,7 +36,6 @@ type Config struct {
 	Region      string   `json:"regions"`
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
-	Region      []string `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -29,6 +29,7 @@ type Payload struct {
 	ContentDeployment string `json:"contentDeployment"`
 	TTLUnit           string `json:"ttlUnit"`
 	TTLValue          int64  `json:"ttlValue"`
+	TimeToExpire      string `json:"timeToExpire"`
 }
 
 type Config struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -34,6 +34,7 @@ type Payload struct {
 type Config struct {
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
+	Region      []string `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -28,8 +28,8 @@ type Payload struct {
 	SnapShot          string `json:"snapShot"`
 	ContentDeployment string `json:"contentDeployment"`
 	TTLUnit           string `json:"ttlUnit"`
-	TTLValue          int64  `json:"ttlValue"`
 	TimeToExpire      string `json:"timeToExpire"`
+	TTLValue          int64  `json:"ttlValue"`
 }
 
 type Config struct {


### PR DESCRIPTION
Currently, the design of this application allows the users to take snapshots of the servers that they are using. However, the snapshots that are taken is based on an EBS snapshot instead of an AMI which are not useful for them.

This PR aims to fix that issue by allowing them to take an AMI snapshot and making it an option the next time they want to deploy a new server.

Fixes #5.