### PR TITLE
feat: added input support for ec2 sizes, ami types, user data and route53 registration

### DIFF
--- a/client/src/app/create-deployment/create-deployment.component.html
+++ b/client/src/app/create-deployment/create-deployment.component.html
@@ -29,7 +29,7 @@
               <mat-form-field floatLabel="always" appearance="outline">
                 <mat-label>Region</mat-label>
                 <mat-select formControlName="region">
-                  <mat-option *ngFor="let region of regions" [value]="region">{{
+                  <mat-option [value]="region">{{
                     region
                   }}</mat-option>
                 </mat-select>

--- a/client/src/app/create-deployment/create-deployment.component.html
+++ b/client/src/app/create-deployment/create-deployment.component.html
@@ -29,9 +29,7 @@
               <mat-form-field floatLabel="always" appearance="outline">
                 <mat-label>Region</mat-label>
                 <mat-select formControlName="region">
-                  <mat-option [value]="region">{{
-                    region
-                  }}</mat-option>
+                  <mat-option [value]="region">{{ region }}</mat-option>
                 </mat-select>
               </mat-form-field>
             </div>

--- a/client/src/app/create-deployment/create-deployment.component.ts
+++ b/client/src/app/create-deployment/create-deployment.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ApiService } from '../shared/services/api.service';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Lifecycle, Region, TimeUnit } from '../shared/enum/dropdown.enum';
+import { Lifecycle, TimeUnit } from '../shared/enum/dropdown.enum';
 import { DeploymentApiRequest } from '../shared/model/deployment-request';
 import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -19,7 +19,7 @@ export class CreateDeploymentComponent implements OnInit {
   deploymentForm!: FormGroup;
   serverSizes: string[] = [];
   amis: string[] = [];
-  regions: Region[] = [Region.AP_SOUTHEAST_3];
+  regions: string[] = [];
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];
 

--- a/client/src/app/create-deployment/create-deployment.component.ts
+++ b/client/src/app/create-deployment/create-deployment.component.ts
@@ -19,7 +19,7 @@ export class CreateDeploymentComponent implements OnInit {
   deploymentForm!: FormGroup;
   serverSizes: string[] = [];
   amis: string[] = [];
-  region: string = "";
+  region: string = '';
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];
 

--- a/client/src/app/create-deployment/create-deployment.component.ts
+++ b/client/src/app/create-deployment/create-deployment.component.ts
@@ -66,10 +66,11 @@ export class CreateDeploymentComponent implements OnInit {
     this.apiService.getAWSData().subscribe((data) => {
       this.serverSizes = data.serverSizes;
       this.amis = data.amis;
+      this.regions = data.regions;
 
       this.deploymentForm.get('serverSize')?.patchValue('t3.medium');
       this.deploymentForm.get('ami')?.patchValue(this.amis[0]);
-      this.deploymentForm.get('region')?.patchValue(Region.AP_SOUTHEAST_3);
+      this.deploymentForm.get('region')?.patchValue(this.regions[0]);
     });
   }
 

--- a/client/src/app/create-deployment/create-deployment.component.ts
+++ b/client/src/app/create-deployment/create-deployment.component.ts
@@ -19,7 +19,7 @@ export class CreateDeploymentComponent implements OnInit {
   deploymentForm!: FormGroup;
   serverSizes: string[] = [];
   amis: string[] = [];
-  regions: string[] = [];
+  region: string = "";
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];
 
@@ -66,11 +66,11 @@ export class CreateDeploymentComponent implements OnInit {
     this.apiService.getAWSData().subscribe((data) => {
       this.serverSizes = data.serverSizes;
       this.amis = data.amis;
-      this.regions = data.regions;
+      this.region = data.regions;
 
       this.deploymentForm.get('serverSize')?.patchValue('t3.medium');
       this.deploymentForm.get('ami')?.patchValue(this.amis[0]);
-      this.deploymentForm.get('region')?.patchValue(this.regions[0]);
+      this.deploymentForm.get('region')?.patchValue(this.region);
     });
   }
 

--- a/client/src/app/edit-deployment/edit-deployment.component.html
+++ b/client/src/app/edit-deployment/edit-deployment.component.html
@@ -29,7 +29,7 @@
               <mat-form-field floatLabel="always" appearance="outline">
                 <mat-label>Region</mat-label>
                 <mat-select formControlName="region">
-                  <mat-option *ngFor="let region of regions" [value]="region">{{
+                  <mat-option [value]="region">{{
                     region
                   }}</mat-option>
                 </mat-select>

--- a/client/src/app/edit-deployment/edit-deployment.component.html
+++ b/client/src/app/edit-deployment/edit-deployment.component.html
@@ -29,9 +29,7 @@
               <mat-form-field floatLabel="always" appearance="outline">
                 <mat-label>Region</mat-label>
                 <mat-select formControlName="region">
-                  <mat-option [value]="region">{{
-                    region
-                  }}</mat-option>
+                  <mat-option [value]="region">{{ region }}</mat-option>
                 </mat-select>
               </mat-form-field>
             </div>

--- a/client/src/app/edit-deployment/edit-deployment.component.ts
+++ b/client/src/app/edit-deployment/edit-deployment.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Region, Lifecycle, TimeUnit } from '../shared/enum/dropdown.enum';
+import { Lifecycle, TimeUnit } from '../shared/enum/dropdown.enum';
 import { DeploymentApiRequest } from '../shared/model/deployment-request';
 import { ApiService } from '../shared/services/api.service';
 import { Subject, filter, switchMap, takeUntil, tap } from 'rxjs';
@@ -20,7 +20,7 @@ export class EditDeploymentComponent {
   editDeploymentForm!: FormGroup;
   serverSizes: string[] = [];
   amis: string[] = [];
-  regions: Region[] = [Region.AP_SOUTHEAST_3];
+  region: string = "";
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];
   currentExpiry: string = '';
@@ -73,7 +73,7 @@ export class EditDeploymentComponent {
         tap((data) => {
           this.serverSizes = data.serverSizes;
           this.amis = data.amis;
-          this.regions = data.regions;
+          this.region = data.regions;
         }),
         switchMap(() => this.deploymentService.currentEdit$),
         filter((editObject): editObject is string => !!editObject),

--- a/client/src/app/edit-deployment/edit-deployment.component.ts
+++ b/client/src/app/edit-deployment/edit-deployment.component.ts
@@ -80,8 +80,7 @@ export class EditDeploymentComponent {
         switchMap((editObject) => this.apiService.getDeployment(editObject)),
         takeUntil(this.ngUnsubscribe),
       )
-      .subscribe((response: any) => { 
-        console.log(response)
+      .subscribe((response: any) => {
         this.editDeploymentForm.reset({}, { emitEvent: false });
         this.editDeploymentForm.patchValue({
           id: response.ID,

--- a/client/src/app/edit-deployment/edit-deployment.component.ts
+++ b/client/src/app/edit-deployment/edit-deployment.component.ts
@@ -73,13 +73,15 @@ export class EditDeploymentComponent {
         tap((data) => {
           this.serverSizes = data.serverSizes;
           this.amis = data.amis;
+          this.regions = data.regions;
         }),
         switchMap(() => this.deploymentService.currentEdit$),
         filter((editObject): editObject is string => !!editObject),
         switchMap((editObject) => this.apiService.getDeployment(editObject)),
         takeUntil(this.ngUnsubscribe),
       )
-      .subscribe((response: any) => {
+      .subscribe((response: any) => { 
+        console.log(response)
         this.editDeploymentForm.reset({}, { emitEvent: false });
         this.editDeploymentForm.patchValue({
           id: response.ID,

--- a/client/src/app/edit-deployment/edit-deployment.component.ts
+++ b/client/src/app/edit-deployment/edit-deployment.component.ts
@@ -20,7 +20,7 @@ export class EditDeploymentComponent {
   editDeploymentForm!: FormGroup;
   serverSizes: string[] = [];
   amis: string[] = [];
-  region: string = "";
+  region: string = '';
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];
   currentExpiry: string = '';

--- a/client/src/app/shared/model/deployment-request.ts
+++ b/client/src/app/shared/model/deployment-request.ts
@@ -1,4 +1,4 @@
-import { Lifecycle, Region, TimeUnit } from '../enum/dropdown.enum';
+import { Lifecycle, TimeUnit } from '../enum/dropdown.enum';
 
 export class DeploymentApiRequest {
   id?: string;
@@ -6,7 +6,7 @@ export class DeploymentApiRequest {
   ami!: number;
   serverSize!: string;
   hostname!: string;
-  region!: Region;
+  region!: string;
   lifecycle!: Lifecycle;
   ttlValue?: number;
   ttlUnit?: string;

--- a/ecr-scripts/instance.tf
+++ b/ecr-scripts/instance.tf
@@ -15,12 +15,29 @@ resource "aws_instance" "my_deployed_on_demand_instances" {
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
   user_data              = data.aws_s3_object.user_data.body
   tags = {
-    Name         = each.value.hostname
+    Name         = "${each.value.hostname}.${data.aws_route53_zone.hosted_zone.name}"
     Hostname     = each.value.hostname
     DeploymentID = each.value.id
     TimeToExpire = each.value.timeToExpire
     DeployedBy   = "turbo-deploy"
   }
+}
+
+resource "aws_eip" "on_demand_ip" {
+  for_each = aws_instance.my_deployed_on_demand_instances
+  instance = each.value.id
+  tags     = {
+    Hostname = each.value.tags_all.Name
+  }
+}
+
+resource "aws_route53_record" "on_demand_record" {
+  for_each = aws_eip.on_demand_ip
+  type     = "A"
+  zone_id  = var.hosted_zone_id
+  name     = each.value.tags_all.Hostname
+  records  = [each.value.public_ip]
+  ttl      = "60"
 }
 
 resource "aws_spot_instance_request" "my_deployed_spot_instances" {
@@ -35,10 +52,27 @@ resource "aws_spot_instance_request" "my_deployed_spot_instances" {
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
   user_data              = data.aws_s3_object.user_data.body
   tags = {
-    Name         = each.value.hostname
+    Name         = "${each.value.hostname}.${data.aws_route53_zone.hosted_zone.name}"
     Hostname     = each.value.hostname
     DeploymentID = each.value.id
     TimeToExpire = each.value.timeToExpire
     DeployedBy   = "turbo-deploy"
   }
+}
+
+resource "aws_eip" "spot_ip" {
+  for_each = aws_spot_instance_request.my_deployed_spot_instances
+  instance = each.value.spot_instance_id
+  tags     = {
+    Hostname = each.value.tags_all.Name
+  }
+}
+
+resource "aws_route53_record" "spot_record" {
+  for_each = aws_eip.spot_ip
+  type     = "A"
+  zone_id  = var.hosted_zone_id
+  name     = each.value.tags_all.Hostname
+  records  = [each.value.public_ip]
+  ttl      = "60"
 }

--- a/ecr-scripts/instance.tf
+++ b/ecr-scripts/instance.tf
@@ -13,6 +13,7 @@ resource "aws_instance" "my_deployed_on_demand_instances" {
   instance_type          = each.value.serverSize
   subnet_id              = local.use_custom_subnet ? var.public_subnet_id : null
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
+  user_data              = data.aws_s3_object.user_data.body
   tags = {
     Name         = each.value.hostname
     Hostname     = each.value.hostname
@@ -32,6 +33,7 @@ resource "aws_spot_instance_request" "my_deployed_spot_instances" {
   instance_type          = each.value.serverSize
   subnet_id              = local.use_custom_subnet ? var.public_subnet_id : null
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
+  user_data              = data.aws_s3_object.user_data.body
   tags = {
     Name         = each.value.hostname
     Hostname     = each.value.hostname

--- a/ecr-scripts/instance.tf
+++ b/ecr-scripts/instance.tf
@@ -15,8 +15,8 @@ resource "aws_instance" "my_deployed_on_demand_instances" {
   vpc_security_group_ids = local.use_custom_security_group ? [var.security_group_id] : null
   user_data              = data.aws_s3_object.user_data.body
   tags = {
-    Name         = "${each.value.hostname}.${data.aws_route53_zone.hosted_zone.name}"
-    Hostname     = each.value.hostname
+    Name         = each.value.hostname
+    Hostname     = replace(each.value.hostname, "/.${data.aws_route53_zone.hosted_zone.name}/", "")
     DeploymentID = each.value.id
     TimeToExpire = each.value.timeToExpire
     DeployedBy   = "turbo-deploy"
@@ -26,8 +26,8 @@ resource "aws_instance" "my_deployed_on_demand_instances" {
 resource "aws_eip" "on_demand_ip" {
   for_each = aws_instance.my_deployed_on_demand_instances
   instance = each.value.id
-  tags     = {
-    Hostname = each.value.tags_all.Name
+  tags = {
+    Hostname = each.value.tags_all.Hostname
   }
 }
 
@@ -53,7 +53,7 @@ resource "aws_spot_instance_request" "my_deployed_spot_instances" {
   user_data              = data.aws_s3_object.user_data.body
   tags = {
     Name         = "${each.value.hostname}.${data.aws_route53_zone.hosted_zone.name}"
-    Hostname     = each.value.hostname
+    Hostname     = replace(each.value.hostname, "/.${data.aws_route53_zone.hosted_zone.name}/", "")
     DeploymentID = each.value.id
     TimeToExpire = each.value.timeToExpire
     DeployedBy   = "turbo-deploy"
@@ -63,8 +63,8 @@ resource "aws_spot_instance_request" "my_deployed_spot_instances" {
 resource "aws_eip" "spot_ip" {
   for_each = aws_spot_instance_request.my_deployed_spot_instances
   instance = each.value.spot_instance_id
-  tags     = {
-    Hostname = each.value.tags_all.Name
+  tags = {
+    Hostname = each.value.tags_all.Hostname
   }
 }
 

--- a/ecr-scripts/main.tf
+++ b/ecr-scripts/main.tf
@@ -35,6 +35,17 @@ variable "public_subnet_id" {
   default     = ""
 }
 
+variable "hosted_zone_id" {
+  description = "ID of the hosted zone for DNS"
+  type        = string
+  default     = ""
+}
+
+data "aws_route53_zone" "hosted_zone" {
+  zone_id      = ""
+  private_zone = false
+}
+
 data "aws_s3_object" "user_data" {
   bucket = "turbo-deploy-luqman"
   key    = "user-data-scripts/user-data.sh"

--- a/ecr-scripts/main.tf
+++ b/ecr-scripts/main.tf
@@ -35,3 +35,7 @@ variable "public_subnet_id" {
   default     = ""
 }
 
+data "aws_s3_object" "user_data" {
+  bucket = "turbo-deploy-luqman"
+  key    = "user-data-scripts/user-data.sh"
+}

--- a/ecr-scripts/main.tf.tpl
+++ b/ecr-scripts/main.tf.tpl
@@ -34,3 +34,8 @@ variable "public_subnet_id" {
   type        = string
   default     = "${PUBLIC_SUBNET_ID}"
 }
+
+data "aws_s3_object" "user_data" {
+  bucket = "${S3_BUCKET_NAME}" 
+  key    = "user-data-scripts/user-data.sh"
+}

--- a/ecr-scripts/main.tf.tpl
+++ b/ecr-scripts/main.tf.tpl
@@ -35,6 +35,17 @@ variable "public_subnet_id" {
   default     = "${PUBLIC_SUBNET_ID}"
 }
 
+variable "hosted_zone_id" {
+  description = "ID of the hosted zone for DNS"
+  type        = string
+  default     = "${HOSTED_ZONE_ID}"
+}
+
+data "aws_route53_zone" "hosted_zone" {
+  zone_id      = "${HOSTED_ZONE_ID}" 
+  private_zone = false
+}
+
 data "aws_s3_object" "user_data" {
   bucket = "${S3_BUCKET_NAME}" 
   key    = "user-data-scripts/user-data.sh"

--- a/server/handler.go
+++ b/server/handler.go
@@ -238,16 +238,19 @@ func DeleteAllInstanceRequests(c *gin.Context) {
 func GetAWSData(c *gin.Context) {
 	// read env variable
 	configEnv := os.Getenv("MY_AMI_ATTR")
+	regionEnv := os.Getenv("MY_REGION")
 
 	config := models.Config{}
 
 	err := json.Unmarshal([]byte(configEnv), &config)
 
+	config.Region = []string{regionEnv}
+
 	if err != nil {
 		log.Println(err)
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, config)
 }
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -236,31 +236,18 @@ func DeleteAllInstanceRequests(c *gin.Context) {
 }
 
 func GetAWSData(c *gin.Context) {
-	// read config file
-	configFile, err := os.ReadFile("config.json")
+	// read env variable
+	configEnv := os.Getenv("MY_AMI_ATTR")
+
+	config := models.Config{}
+
+	err := json.Unmarshal([]byte(configEnv), &config)
+
 	if err != nil {
-		log.Printf("Failed to read config file: %v", err)
-		abortWithLog(c, http.StatusInternalServerError, err)
+		log.Println(err)
 		return
 	}
-
-	// parse config file
-	var config models.Config
-	if err := json.Unmarshal(configFile, &config); err != nil {
-		log.Printf("Error parsing config file: %v", err)
-		abortWithLog(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	// instanceTypes, err := GetEC2InstanceTypes(c.Request.Context())
-	// if err != nil {
-	// 	log.Printf("Error fetching EC2 instance types: %v", err)
-	// 	abortWithLog(c, http.StatusInternalServerError, err)
-	// 	return
-	// }
-
-	// config.ServerSizes = instanceTypes
-
+	
 	c.JSON(http.StatusOK, config)
 }
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -81,12 +81,16 @@ func CreateInstanceRequest(c *gin.Context) {
 		return
 	}
 
+	// get hostname and concat with domain
+	domainEnv := os.Getenv("DOMAIN_NAME")
+	hostname := req.Hostname + "." + domainEnv
+
 	// Convert request to DynamoDBData struct
 	data := models.DynamoDBData{
 		ID:                uuid.New().String()[:8],
 		Ami:               req.Ami,
 		ServerSize:        req.ServerSize,
-		Hostname:          req.Hostname,
+		Hostname:          hostname,
 		Region:            req.Region,
 		CreationUser:      req.CreationUser,
 		Lifecycle:         req.Lifecycle,

--- a/server/handler.go
+++ b/server/handler.go
@@ -249,7 +249,7 @@ func GetAWSData(c *gin.Context) {
 	}
 
 	// add region env
-	config.Region = []string{regionEnv}
+	config.Region = regionEnv
 
 	c.JSON(http.StatusOK, config)
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -243,21 +243,15 @@ func GetAWSData(c *gin.Context) {
 	config := models.Config{}
 
 	err := json.Unmarshal([]byte(configEnv), &config)
-
-	config.Region = []string{regionEnv}
-
 	if err != nil {
-		log.Println(err)
+		log.Printf("Failed to describe unmarshal ec2 configuration: %v", err)
 		return
 	}
 
-	c.JSON(http.StatusOK, config)
-}
+	// add region env
+	config.Region = []string{regionEnv}
 
-func abortWithLog(c *gin.Context, statusCode int, err error) {
-	if abortErr := c.AbortWithError(statusCode, err); abortErr != nil {
-		log.Printf("Failed to abort with status %d: %v", statusCode, abortErr)
-	}
+	c.JSON(http.StatusOK, config)
 }
 
 func GetEC2InstanceTypes(ctx context.Context) ([]string, error) {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -34,6 +34,7 @@ type Payload struct {
 type Config struct {
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
+	Region		[]string `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -35,7 +35,7 @@ type Payload struct {
 type Config struct {
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
-	Region      []string `json:"regions"`
+	Region      string   `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -29,12 +29,13 @@ type Payload struct {
 	ContentDeployment string `json:"contentDeployment"`
 	TTLUnit           string `json:"ttlUnit"`
 	TTLValue          int64  `json:"ttlValue"`
+	TimeToExpire      string `json:"timeToExpire"`
 }
 
 type Config struct {
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
-	Region		[]string `json:"regions"`
+	Region      []string `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -33,9 +33,9 @@ type Payload struct {
 }
 
 type Config struct {
+	Region      string   `json:"regions"`
 	ServerSizes []string `json:"serverSizes"`
 	Ami         []string `json:"amis"`
-	Region      string   `json:"regions"`
 }
 
 type DeploymentResponse struct {

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -28,8 +28,8 @@ type Payload struct {
 	SnapShot          string `json:"snapShot"`
 	ContentDeployment string `json:"contentDeployment"`
 	TTLUnit           string `json:"ttlUnit"`
-	TTLValue          int64  `json:"ttlValue"`
 	TimeToExpire      string `json:"timeToExpire"`
+	TTLValue          int64  `json:"ttlValue"`
 }
 
 type Config struct {


### PR DESCRIPTION
## SUMMARY
In conjunction with the changes in the module in this [PR](https://github.com/frgrisk/terraform-aws-turbo-deploy/pull/8). The logic of the lambda functions will be changed to accommodate extra features that allows for defining several things during the Turbo infrastructure deployment:
1. Added EC2 Types
2. Added AMI Types
3. Added user data scripts
4. Added route53 registration

## TEST PLAN
1. Create an ECR repository in your AWS environment
2. Run the ecr-scripts/deploy_lambda.sh script to push a new image to that repository
3. Create a Route53 Hosted Zone in your AWS environment
4. Run make build to create the bootstrap binary for lambda function
5. Zip bootstrap binary into a zip file
6. During Terraform deployment of the Turbo Infrastructure, define the following variables: 
- `source`, source of the module in github, in this case we will use "git::https://github.com/frgrisk/terraform-aws-turbo-deploy.git?ref=dd11728875ddbb6ffd03279ea061186d3efbf76f"
- `lambda_function_zip_path`, this is the path to the zip file you previously created
- `ecr_repository_name`, name of your repository with the image
- `zone_id`, ID of the hosted zone you created
- `s3_tf_bucket_name`, name of the bucket that will be created
- `user_scripts`, PATH to the user script that you want to upload
- `ec2_attributes`, The types of ec2 instances and AMIs that will be displayed

Below is an example image of what this can look like:
![image](https://github.com/user-attachments/assets/53191912-95ab-433c-ba40-e0975c7355b7)

7. Modify the reverse proxy with the base_url in the output and verify that the functions stated before is working as expected in the web application
