### PR TITLE
ci: Add workflow for building and pushing docker image to ecr for aws lambda

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,49 @@
+name: AWS Lambda Image Build
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  ECR_REPOSITORY_NAME: turbo-deploy-tf-function
+  AWS_REGION: us-east-2
+
+jobs:
+  build:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::560610306577:role/turbo-deploy-github-actions
+          role-session-name: turbo-deploy-github-actions-role-session
+
+      - name: Test aws creds
+        id: aws_account_id
+        shell: bash
+        run: echo "AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> $GITHUB_ENV
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push the image to Amazon ECR
+        working-directory: ./ecr-scripts
+        id: build-image
+        env:
+          AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
+        run: |
+          docker build --build-arg AWS_DEFAULT_REGION=$AWS_REGION -t $ECR_REPOSITORY_NAME:latest .
+          docker tag $ECR_REPOSITORY_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY_NAME:latest
+          docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY_NAME:latest
+
+
+
+      

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,7 +2,7 @@ name: AWS Lambda Image Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   ECR_REPOSITORY_NAME: turbo-deploy-tf-function
@@ -43,7 +43,3 @@ jobs:
           docker build --build-arg AWS_DEFAULT_REGION=$AWS_REGION -t $ECR_REPOSITORY_NAME:latest .
           docker tag $ECR_REPOSITORY_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY_NAME:latest
           docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY_NAME:latest
-
-
-
-      


### PR DESCRIPTION
Currently, the docker image used for the aws lambda is being built and pushed locally, this PR aims to make it so that any push towards the main branch will automatically build and push the docker image to the corresponding ECR repository.