### PR TITLE
fix: migrate changes made on create to edit

### DIFF
--- a/client/src/app/edit-deployment/edit-deployment.component.html
+++ b/client/src/app/edit-deployment/edit-deployment.component.html
@@ -40,10 +40,8 @@
               <mat-form-field floatLabel="always" appearance="outline">
                 <mat-label>AMI Choice</mat-label>
                 <mat-select formControlName="ami">
-                  <mat-option
-                    *ngFor="let ami of amis | keyvalue"
-                    [value]="ami.key"
-                    >{{ ami.value }}</mat-option
+                  <mat-option *ngFor="let ami of amis" [value]="ami.amiIds"
+                    >({{ ami.amiIds }}) {{ ami.amiNames }}</mat-option
                   >
                 </mat-select>
               </mat-form-field>

--- a/client/src/app/edit-deployment/edit-deployment.component.ts
+++ b/client/src/app/edit-deployment/edit-deployment.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Lifecycle, TimeUnit } from '../shared/enum/dropdown.enum';
+import { Lifecycle, TimeUnit, AmiAttr } from '../shared/enum/dropdown.enum';
 import { DeploymentApiRequest } from '../shared/model/deployment-request';
 import { ApiService } from '../shared/services/api.service';
 import { Subject, filter, switchMap, takeUntil, tap } from 'rxjs';
@@ -19,7 +19,7 @@ export class EditDeploymentComponent {
 
   editDeploymentForm!: FormGroup;
   serverSizes: string[] = [];
-  amis: Map<string, string> = new Map<string, string>();
+  amis: AmiAttr[] = [];
   region: string = '';
   lifecycles: Lifecycle[] = [Lifecycle.ON_DEMAND, Lifecycle.SPOT];
   ttlUnits: TimeUnit[] = [TimeUnit.HOURS, TimeUnit.DAYS, TimeUnit.MONTHS];


### PR DESCRIPTION
Previously changes were made on the create instance form to display the instances in a sorted order, this change should have applied to the edit form too but was missed during development. The aim of this PR is to fix the edit form by correctly applying the change.